### PR TITLE
Reconnect when postgres connection drops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
 script:
   - TEST_PG_DATABASE=ptest TEST_PG_USER=ptest TEST_PG_PASSWORD=ptest nosetests
 addons:
-    postgresql: "9.1"
+    postgresql: "9.2"


### PR DESCRIPTION
Which can happen when the server is restarted or a network partition
occurs. We've observed this happen when running postgres-api over a period
of days.

The test simulates this by creating a new connection and issuing a
statement that kills all connections except for itself. It then makes two
attempts to create an instance from a shared plan - the first of which is
expected to receive an error when it notices that the connection has been
reset, the second of which should reconnect and succeed.

Fix this by disabling Flask's caching/memoisation of the connection and
establish a new connection if there either a) hasn't been one previously, b)
it notices that the connection has been closed.

I'm certain that this isn't threadsafe because there is no mutex (or
ratelimit) on establishing new connections. I'm not clear though whether
this app was ever intended to be. I'm guessing not, because a single
connection was shared. I did look at using psycopg2's connection pools but
it seemed like it might be overkill and I wasn't sure how to size the pool.
There is also SQLalchemy, which does some of this stuff for you, but again
it seems like overkill.

The test (and others which subsequently depend on there being a connection)
will fail as follows without those modifications:

```
======================================================================
ERROR: test_disconnected (tests.test_database.DatabaseTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/pgapi/tests/test_database.py", line 61, in test_disconnected
    instance = manager.create_instance(cdb_name)
  File "/pgapi/postgresapi/managers.py", line 36, in create_instance
    if self.storage.instance_exists(name):
  File "/pgapi/postgresapi/storage.py", line 53, in instance_exists
    with app.db.transaction() as cursor:
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/pgapi/postgresapi/database.py", line 35, in transaction
    orig_level = conn.isolation_level
InterfaceError: connection already closed

======================================================================
ERROR: test_disconnected (tests.test_database.DatabaseTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/pgapi/tests/_base.py", line 57, in tearDown
    manage.downgrade_db()
  File "/pgapi/postgresapi/manage.py", line 75, in downgrade_db
    from_version = _get_db_revision()
  File "/pgapi/postgresapi/manage.py", line 16, in _get_db_revision
    with app.db.autocommit() as cursor:
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/pgapi/postgresapi/database.py", line 52, in autocommit
    orig_level = conn.isolation_level
InterfaceError: connection already closed

----------------------------------------------------------------------
Ran 1 test in 0.035s

FAILED (errors=2)
```
