### PR TITLE
Leftover role bug fixed

### DIFF
--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -25,6 +25,8 @@ class DeleteTestCase(_base.TestCase):
             cursor.execute('CREATE ROLE databaseno_group')
             cursor.execute('CREATE DATABASE databasenotexist '
                            'OWNER databaseno_group')
+            cursor.execute('CREATE ROLE databaseno90ae84 '
+                           'IN GROUP databaseno_group')
         with self.app.app_context():
             manager = managers.SharedManager()
             manager.delete_instance(models.Instance(name='databasenotexist', plan='shared'))
@@ -32,6 +34,8 @@ class DeleteTestCase(_base.TestCase):
         db = self.create_db()
         with db.transaction() as cursor:
             cursor.execute('SELECT * FROM instance')
+            self.assertEqual(cursor.fetchall(), [])
+            cursor.execute("SELECT * FROM pg_roles WHERE rolname ='databaseno90ae84'")
             self.assertEqual(cursor.fetchall(), [])
 
     def test_not_exist(self):

--- a/tests/test_unbind.py
+++ b/tests/test_unbind.py
@@ -26,6 +26,9 @@ class UnbindTestCase(_base.TestCase):
             manager = managers.SharedManager()
             instance = manager.create_instance('databasenotexist')
             instance.drop_user('127.0.0.1')
+        with db.transaction() as cursor:
+            cursor.execute("SELECT * FROM pg_roles WHERE rolname = 'databaseno90ae84'")
+            self.assertEqual(cursor.fetchall(), [])
 
     def test_not_found(self):
         with self.app.app_context():


### PR DESCRIPTION
When you delete a service instance without unbinding first,
there is a bug where a member role is left in the database.

This causes an error when trying to recreate the service instance
and bind it again. This can be proved to be a bug easily:

```
curl -XPOST http://127.0.0.1:5000/resources -v -d "name=foo"
curl -XPOST http://127.0.0.1:5000/resources/foo/bind-app -v -d
"app-host=htapphost"
curl -XDELETE http://127.0.0.1:5000/resources/foo -v
```

Now try to create the same service instance and
bind it to the same app.

You will get an error saying the role exists already.

See this issue: https://github.com/tsuru/postgres-api/issues/1
