### PR TITLE
Roles with related objects are dropped after unbind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
 script:
   - TEST_PG_DATABASE=ptest TEST_PG_USER=ptest TEST_PG_PASSWORD=ptest nosetests
 addons:
-    postgresql: "9.2"
+    postgresql: "9.3"

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -2,7 +2,7 @@
 
 import psycopg2
 
-from postgresapi import models, managers, storage
+from postgresapi import managers, storage
 from . import _base
 
 

--- a/tests/test_unbind.py
+++ b/tests/test_unbind.py
@@ -2,7 +2,7 @@
 
 import psycopg2
 
-from postgresapi import models, managers
+from postgresapi import managers, database
 from . import _base
 
 
@@ -19,16 +19,50 @@ class UnbindTestCase(_base.TestCase):
         self._drop_test_user()
 
     def test_success(self):
-        db = self.create_db()
-        with db.autocommit() as cursor:
-            cursor.execute('CREATE ROLE databaseno90ae84')
+        user = self.user
+        dbname = self.database
+
+        # Connection to the database using app's user credentials
+        self.database = 'databasenotexist'
+        self.user = 'databaseno90ae84'
+        user_db = self.create_db()
+
+        # Connection to the same db instance but logging in as main user
+        # This will be used to check the table we create is still there
+        # when the app is unbound
+        self.user = user
+        group_db = self.create_db()
+
+        # Reset the username and db name so setUp and tearDown methods work
+        self.user = user
+        self.database = dbname
+
         with self.app.app_context():
             manager = managers.SharedManager()
             instance = manager.create_instance('databasenotexist')
+            instance.create_user('127.0.0.1')
+
+            # Let's simulate the app creating some objects in the database
+            # This could be a Django/Flask app running migrations, for instance
+            with user_db.autocommit() as cursor:
+                cursor.execute('CREATE TABLE article ('
+                               'article_id bigserial primary key, '
+                               'article_name varchar(20) NOT NULL, '
+                               'article_desc text NOT NULL, '
+                               'date_added timestamp default NULL)')
+                cursor.execute('INSERT INTO article('
+                               'article_id, article_name, article_desc, date_added) '
+                               'VALUES(1, \'hello\', \'world world world\', NOW())')
+
             instance.drop_user('127.0.0.1')
-        with db.transaction() as cursor:
+
+        with group_db.transaction() as cursor:
+            # The role created after binding the app should be gone
             cursor.execute("SELECT * FROM pg_roles WHERE rolname = 'databaseno90ae84'")
             self.assertEqual(cursor.fetchall(), [])
+            # The table created by the app should be still here containing all data
+            cursor.execute("SELECT * FROM article")
+            self.assertEqual(len(cursor.fetchall()), 1)
 
     def test_not_found(self):
         with self.app.app_context():


### PR DESCRIPTION
Related issue: https://github.com/tsuru/postgres-api/issues/13

There was another issue with the Postgres API. This one causes unbinding
of an app to fail if the app has created some objects in the database
(for example a Django or Flask app which ran migrations after being
bound to instance of Postgres service).

Create a service instance and bind an app.

```
curl -XPOST http://127.0.0.1:5000/resources -v -d "name=foo"
curl -XPOST http://127.0.0.1:5000/resources/foo/bind-app -v -d
"app-host=htapphost"
```

Now connect to the database as the newly created user for the app and
create some objects.

```
psql -U foob28f9c foo
psql (9.4.4)
Type "help" for help.

foo=>
CREATE TABLE article (
     article_id bigserial primary key,
     article_name varchar(20) NOT NULL,
     article_desc text NOT NULL,
     date_added timestamp default NULL
);
foo=>
```

Insert some rows into the table:

```
INSERT INTO article(article_id, article_name, article_desc, date_added)
VALUES(2, 'hello', 'world world', NOW())
```

Try to unbind the app:

```
curl -XDELETE http://127.0.0.1:5000/resources/foo/bind-app -v -d
"app-host=htapphost"
```

You will get this error:

```
role "foob28f9c" cannot be dropped because some objects depend on it
DETAIL:  owner of table article
owner of sequence article_article_id_seq
```
